### PR TITLE
Use `const` where possible

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,3 +3,6 @@ linter:
   rules:
     - sort_constructors_first
     - sort_unnamed_constructors_first
+    - prefer_const_constructors
+    - prefer_const_declarations
+    - unnecessary_const

--- a/lib/src/expression/nodes.dart
+++ b/lib/src/expression/nodes.dart
@@ -4,7 +4,7 @@ import 'package:maybe_just_nothing/maybe_just_nothing.dart';
 typedef Nodes = Iterable<Node>;
 
 extension NodesExt on Nodes {
-  Maybe get asValue => length == 1 ? Just(single.value) : Nothing();
+  Maybe get asValue => length == 1 ? Just(single.value) : const Nothing();
 
   bool get asLogical => isNotEmpty;
 }

--- a/lib/src/fun/extra/reverse.dart
+++ b/lib/src/fun/extra/reverse.dart
@@ -2,6 +2,7 @@ import 'package:json_path/fun_sdk.dart';
 
 /// Reverses the string.
 class Reverse implements Fun1<Maybe, Maybe> {
+  const Reverse();
   @override
   final name = 'reverse';
 

--- a/lib/src/fun/extra/siblings.dart
+++ b/lib/src/fun/extra/siblings.dart
@@ -2,6 +2,7 @@ import 'package:json_path/fun_sdk.dart';
 
 /// Returns all siblings of the given nodes.
 class Siblings implements Fun1<Nodes, Nodes> {
+  const Siblings();
   @override
   final name = 'siblings';
 

--- a/lib/src/fun/extra/xor.dart
+++ b/lib/src/fun/extra/xor.dart
@@ -1,6 +1,8 @@
 import 'package:json_path/fun_sdk.dart';
 
 class Xor implements Fun2<bool, bool, bool> {
+  const Xor();
+
   @override
   final name = 'xor';
 

--- a/test/cases_test.dart
+++ b/test/cases_test.dart
@@ -8,13 +8,13 @@ void main() {
   runTestsInDirectory('test/cases/standard');
   runTestsInDirectory('test/cases/extra',
       parser: JsonPathParser(functions: [
-        IsArray(),
-        IsBoolean(),
-        IsNumber(),
-        IsObject(),
-        IsString(),
-        Reverse(),
-        Siblings(),
-        Xor(),
+        const IsArray(),
+        const IsBoolean(),
+        const IsNumber(),
+        const IsObject(),
+        const IsString(),
+        const Reverse(),
+        const Siblings(),
+        const Xor(),
       ]));
 }

--- a/test/expression_test.dart
+++ b/test/expression_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('Expression', () {
     group('Static', () {
       final node = Node('foo');
-      final s = StaticExpression(Just('bar'));
+      final s = StaticExpression(const Just('bar'));
       final d = Expression((Node n) => Just(n.value));
       test('map()', () {
         expect(s.map((v) => v.map((v) => '$v!').or('oops')).call(node), 'bar!');

--- a/test/functions_test.dart
+++ b/test/functions_test.dart
@@ -8,9 +8,9 @@ import 'package:test/test.dart';
 void main() {
   final store = jsonDecode(File('test/store.json').readAsStringSync());
   final parser = JsonPathParser(functions: [
-    Reverse(),
-    Siblings(),
-    Xor(),
+    const Reverse(),
+    const Siblings(),
+    const Xor(),
   ]);
   group('User-defined functions', () {
     test('Fun<Nodes> in Nodes context', () {

--- a/test/json_path_test.dart
+++ b/test/json_path_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   group('JSONPath', () {
     test('toString()', () {
-      final expr = r'$.foo.bar';
+      const expr = r'$.foo.bar';
       expect('${JsonPath(expr)}', equals(expr));
     });
   });

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -13,11 +13,11 @@ import 'package:test/test.dart';
 
 void main() {
   final parser = JsonPathGrammarDefinition(FunFactory(<Fun>[
-    Length(),
-    Count(),
-    Match(),
-    Search(),
-    Value(),
+    const Length(),
+    const Count(),
+    const Match(),
+    const Search(),
+    const Value(),
   ])).build();
 
   group('Parser', () {


### PR DESCRIPTION
When using this package I noticed some `const` constructors are missing. 

In this PR I fixed that and added some linter rules to help with this in the future. 