### PR TITLE
memberNameShorthand should allow numbers at the beginning of a name

### DIFF
--- a/lib/src/grammar/strings.dart
+++ b/lib/src/grammar/strings.dart
@@ -83,6 +83,6 @@ final _nameChar = digit() | _nameFirst;
 
 final quotedString = (_singleQuotedString | _doubleQuotedString).cast<String>();
 
-final memberNameShorthand = (_nameFirst & _nameChar.star())
+final memberNameShorthand = (_nameChar & _nameChar.star())
     .flatten('a member name shorthand expected')
     .map(childSelector);


### PR DESCRIPTION
We needed the following JSON Path `$.heads.0.value` 

To extract a value of the following JSON:
```json
{
  "heads": {
     "0": {
       "value": 250
     }
  }
}
```

The JSONPath Syntax allows this (see: https://jsonpath.com/) 
